### PR TITLE
Ansible 2.3.1: "ansible_facts requires 2 arguments"

### DIFF
--- a/library/firewall.py
+++ b/library/firewall.py
@@ -50,7 +50,7 @@ def main():
             state=dict(default='reloaded', choices=['reloaded'])
         )
     )
-    facts = ansible_facts(module)
+    facts = ansible_facts(module, [])
 
     state = module.params['state']
 


### PR DESCRIPTION
Tested with Ansible 2.3.1 https://github.com/ansible/ansible/blob/v2.3.1.0-1/lib/ansible/module_utils/facts.py#L3870-L3878